### PR TITLE
Realtime validation added

### DIFF
--- a/InlineTagController.xcodeproj/xcuserdata/kyle.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/InlineTagController.xcodeproj/xcuserdata/kyle.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -10,12 +10,12 @@
             ignoreCount = "0"
             continueAfterRunningActions = "No"
             filePath = "Sources/InlineTagController.swift"
-            timestampString = "521582474.518573"
+            timestampString = "521658553.292309"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "108"
-            endingLineNumber = "108"
-            landmarkName = "configure()"
+            startingLineNumber = "375"
+            endingLineNumber = "375"
+            landmarkName = "createAndSwitchToNewCell(cell:)"
             landmarkType = "7">
          </BreakpointContent>
       </BreakpointProxy>

--- a/Sources/InlineTagCell.swift
+++ b/Sources/InlineTagCell.swift
@@ -163,6 +163,12 @@ extension InlineTagCell {
             self.delegate?.createAndSwitchToNewCell(cell: self)
         } else if string == "" && textField.text == "" {
             self.delegate?.shouldDeleteCellInFrontOfCell(cell: self)
+        } else if !InlineTagControllerValidation.isValid(text: self.textField.text) {
+            self.set(mode: .invalid)
+            return true
+        } else if InlineTagControllerValidation.isValid(text: self.textField.text) {
+            self.set(mode: .edit)
+            return true
         } else {
             return self.mode == .edit
         }

--- a/Sources/InlineTagConfigurable.swift
+++ b/Sources/InlineTagConfigurable.swift
@@ -82,5 +82,5 @@ extension InlineTagConfigurable {
     public var skipOnReturnKey: Bool { return true }
     public var placeholderText: String { return "Add tags..." }
     public var numberOfTags: NumberOfTags { return .unlimited }
-    public var itemValidation: Validation? { return InlineTagControllerValidation.testEmptiness }
+    public var itemValidation: Validation? { return InlineTagControllerValidation.testLegnth }
 }

--- a/Sources/InlineTagControllerValidation.swift
+++ b/Sources/InlineTagControllerValidation.swift
@@ -24,15 +24,21 @@ public class InlineTagControllerValidation {
     }
 
     public class var testEmailAddress: Validation {
-        return { text in
+        return { (text: String) in
             let emailRegex = "^[+\\w\\.\\-']+@[a-zA-Z0-9-]+(\\.[a-zA-Z0-9-]+)*(\\.[a-zA-Z]{2,})+$"
             let emailTest = NSPredicate(format:"SELF MATCHES %@", emailRegex)
             return emailTest.evaluate(with: text)
         }
     }
 
+    public class var testLegnth: Validation {
+        return { (text: String) in
+            return text.characters.count < 8
+        }
+    }
+
     public class func combine(v1: @escaping Validation, v2: @escaping Validation) -> Validation {
-        return { text in return v1(text) && v2(text) }
+        return { (text: String) in return v1(text) && v2(text) }
     }
 
     public class func isValid(text: String?) -> Bool {


### PR DESCRIPTION
As you type a tag, the cell will shift to an invalid view state once validation is not met but still allow you to edit the tag in real time. 

When in an invalid state, return or space will have to effect until the tag is valid again.